### PR TITLE
Show sponsorship button on Adoptium repositories

### DIFF
--- a/FUNDING.yml
+++ b/FUNDING.yml
@@ -1,0 +1,1 @@
+custom: ['https://eclipse.org/donate/adoptium']

--- a/FUNDING.yml
+++ b/FUNDING.yml
@@ -1,1 +1,1 @@
-custom: ['https://eclipse.org/donate/adoptium']
+custom: ['eclipse.org/donate/adoptium']


### PR DESCRIPTION
See an example of how this will look at https://github.com/gdams/funding

This adds a new option to the side of all GitHub repositories that outlines how you can sponsor this project:
<img width="341" alt="Screenshot 2022-02-18 at 10 12 40" src="https://user-images.githubusercontent.com/20224954/154662682-da9bf4cc-a485-4f06-938a-9f5af3aa7c88.png">


