### PR TITLE
code freeze: Send merge request to Slack

### DIFF
--- a/.github/workflows/code-freeze.yml
+++ b/.github/workflows/code-freeze.yml
@@ -68,7 +68,7 @@ jobs:
         env:
           GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
 
-      - name: Add comment
+      - name: Add approval to merge comment
         if: steps.check.outputs.triggered == 'true'
         uses: peter-evans/create-or-update-comment@v2
         with:
@@ -77,6 +77,17 @@ jobs:
             Approval to merge during the lockdown cycle
             
             Please can two [Adoptium PMC](https://projects.eclipse.org/projects/adoptium/who) members comment `/approve`?
+
+      - name: Send approval to merge comment to Slack
+        if: steps.check.outputs.triggered == 'true'
+        uses: slackapi/slack-github-action@v1.23.0
+        with:
+          payload: |
+            {
+              "link": "https://github.com/${{ github.repository }}/pull/${{ github.event.issue.number }}"
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_CODEFREEZE_URL }}
             
       - uses: khan/pull-request-comment-trigger@v1.1.0
         if: github.event_name == 'issue_comment'

--- a/.github/workflows/code-freeze.yml
+++ b/.github/workflows/code-freeze.yml
@@ -58,8 +58,16 @@ jobs:
           issue-number: ${{ github.event.issue.number }}
           body: Sorry @${{ github.actor }}, the code freeze is still in place.
 
-      - uses: khan/pull-request-comment-trigger@v1.1.0
+      - name: Fetch merge request cache
         if: github.event_name == 'issue_comment'
+        id: merge-request
+        uses: actions/cache@v3
+        with:
+          path: merge-request.txt
+          key: "${{ github.event.issue.number }}-merge-request"
+
+      - uses: khan/pull-request-comment-trigger@v1.1.0
+        if: steps.merge-request.outputs.cache-hit != 'true' && github.event_name == 'issue_comment'
         id: check
         with:
           trigger: '/merge'
@@ -88,9 +96,13 @@ jobs:
             }
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_CODEFREEZE_URL }}
+
+      - name: Store merge request
+        if: steps.check.outputs.triggered == 'true'
+        run: echo true > merge-request.txt
             
       - uses: khan/pull-request-comment-trigger@v1.1.0
-        if: github.event_name == 'issue_comment'
+        if: steps.merge-request.outputs.cache-hit == 'true' && github.event_name == 'issue_comment'
         id: approval
         with:
           trigger: '/approve'


### PR DESCRIPTION
This extends the code freeze bot to send the merge request to the #release channel in Slack