### PR TITLE
Reduce scope of permissions

### DIFF
--- a/.github/workflows/pr-auto-merge.yml
+++ b/.github/workflows/pr-auto-merge.yml
@@ -6,14 +6,16 @@ on:
         required: true
         type: string
 
-permissions:
-  contents: write
-  pull-requests: write
+permissions: {}
 
 jobs:
   automerge:
-    runs-on: ubuntu-latest
     if: ${{ contains(github.event.pull_request.labels.*.name, 'automerge') && github.actor == inputs.allowed-author }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+
     steps:
       - name: Approve pull request
         run: gh pr review --approve "$PR_URL"


### PR DESCRIPTION
OSSF scorecard complains if write permissions are given global scope, so remove all global permissions and move to explicit job scope.