### PR TITLE
Revert token restriction as it breaks job

### DIFF
--- a/.github/workflows/sync-code-of-conduct.yml
+++ b/.github/workflows/sync-code-of-conduct.yml
@@ -4,9 +4,6 @@ on:
   schedule:
     - cron: '0 0 * * *'  # every day at midnight
 
-permissions:
-  contents: read
-
 jobs:
   code-of-conduct:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This change broke the code of conduct sync job so I’m reverting it