### PR TITLE
Initial Allstar policy configuration

### DIFF
--- a/allstar/README.md
+++ b/allstar/README.md
@@ -1,0 +1,12 @@
+# Allstar configurations for the Adoptium organisation
+
+[Allstar](https://github.com/ossf/allstar) is a GitHub App that
+continuously monitors a subset of our organization's repositories
+for adherence to security best practices.
+
+It is configured to create issues on repositories that do not
+comply with the configured policy.
+
+The `yaml` files in this directory contain
+[the list of repositories](allstar.yaml)
+being checked and the various policies being enforced.

--- a/allstar/allstar.yaml
+++ b/allstar/allstar.yaml
@@ -1,0 +1,13 @@
+#
+# Allstar org level configuration
+#
+# https://github.com/ossf/allstar#org-level-options
+#
+
+# Use opt-in strategy, so repos must be explicitly added.
+# 
+optConfig:
+  optOutStrategy: false
+  disableRepoOverride: true
+  optInRepos:
+    - adoptium.net

--- a/allstar/binary_artifacts.yaml
+++ b/allstar/binary_artifacts.yaml
@@ -1,0 +1,22 @@
+#
+# Stored binary artifacts configuration
+#
+# https://github.com/ossf/allstar/blob/main/README.md#binary-artifacts
+#
+  
+# OptConfig is the repo-level opt in/out config.
+#
+optConfig:
+  optOutStrategy: true
+
+# Action: defines which action to take.
+# Valid values log|issue|fix. Overrides the same setting in org-level
+# configuration.
+# https://github.com/ossf/allstar/blob/main/README.md#actions
+action: issue
+
+# IgnorePaths : list of full paths to ignore.
+# Must be full paths with directories. Globs are not allowed. These are
+# allowed even if RepoOverride is false.
+#
+# ignorePaths: ["/bin/"]

--- a/allstar/branch_protection.yaml
+++ b/allstar/branch_protection.yaml
@@ -1,0 +1,74 @@
+#
+# Org level configuration of branch protection policy
+#
+# https://github.com/ossf/allstar/blob/main/README.md#branch-protection
+#
+
+
+# OptConfig : the org-level opt in/out config.
+#
+optConfig:
+  optOutStrategy: true
+
+# Action: defines which action to take.
+# Valid values log|issue|fix. Default: log.
+# https://github.com/ossf/allstar/blob/main/README.md#actions
+#
+action: issue
+
+# EnforceDefault : enforce policy on default branch.
+# Default: true
+#
+# enforceDefault: true
+
+# EnforceBranches : set of non-default branches to enforce policy on.
+# Non-default branches to enforce policy on, such as branches which releases
+# are made from.
+#
+# enforceBranches: [ dev, releases ]
+
+# RequireApproval : enforce approval of PRs.
+# Default: true.
+#
+# requireApproval: true
+
+# RequireCodeOwnerReviews : enforce code owner reviews on PRs.
+# If set to true, then "requireApproval" must also be true. Default: false.
+#
+# requireCodeOwnerReviews: false
+  
+# ApprovalCount : the number of required PR approvals.
+# Default: 1
+#
+approvalCount: 2
+
+# DismissStale : require PR approvals be dismissed when a PR is updated.
+# Default: true.
+#
+# dismissStale: true
+
+# BlockForce : block force pushes.
+# Default: true.
+#
+# blockForce: true
+
+# EnforceOnAdmins : apply the branch protection rules to administrators.
+# Default: true.
+#
+# enforceOnAdmins: true
+
+# RequireUpToDateBranch : branches must be up to date before merging.
+# Only used if RequireStatusChecks is true. Default: true.
+#
+# requireUpToDateBranch: true
+
+# RequireStatusChecks : a list of status checks that are required in
+# order to merge into the protected branch.
+# Each entry must specify the context, and optionally an appID.
+#
+# requireStatusChecks: []
+
+# RequireSignedCommits : require signed commits on protected branches.
+# Default: false.
+#
+# requireSignedCommits: false

--- a/allstar/outside.yaml
+++ b/allstar/outside.yaml
@@ -1,0 +1,31 @@
+#
+# Organisation configuration of outside collaborators policy.
+#
+# https://github.com/ossf/allstar/blob/main/README.md#outside-collaborators
+#
+  
+# OptConfig is the org-level opt in/out config.
+#
+optConfig:
+  optOutStrategy: true
+
+# Action: defines which action to take.
+# Valid values log|issue|fix. Default: log.
+# https://github.com/ossf/allstar/blob/main/README.md#actions
+#
+action: issue
+
+# PushAllowed : outside collaborators are allowed to have push access.
+# Default: true.
+#
+pushAllowed: false
+
+# AdminAllowed : outside collaborators are allowed to have admin access.
+# Default: false.
+#
+#adminAllowed: false
+
+# Exemptions : list of user-repo-access pairings to exempt.
+# Only valid at the org level for security management clarity.
+#
+# exemptions: []

--- a/allstar/security.yaml
+++ b/allstar/security.yaml
@@ -1,0 +1,18 @@
+#
+# Organisation configuration of SECURITY.md check policy.
+#
+# https://github.com/ossf/allstar/blob/main/README.md#securitymd
+#
+# Checks that the repository has a security policy file in
+# SECURITY.md and that it is not empty.
+  
+# OptConfig is the org-level opt in/out config.
+#
+optConfig:
+  optOutStrategy: false
+
+# Action: defines which action to take.
+# Valid values log|issue|fix. Default: log.
+# https://github.com/ossf/allstar/blob/main/README.md#actions
+#
+action: issue


### PR DESCRIPTION
Create initial [Allstar](https://github.com/ossf/allstar#readme) security best practices policy files.

Start with opt-in strategy for a limited set of repos.