### PR TITLE
Initiate code freeze for 2023-07

### DIFF
--- a/.github/workflows/code-freeze.yml
+++ b/.github/workflows/code-freeze.yml
@@ -18,7 +18,7 @@ jobs:
   freeze:
     runs-on: ubuntu-latest
     # Change to false when code freeze is not in place
-    if: github.repository_owner == 'adoptium' && false
+    if: github.repository_owner == 'adoptium' && true
     steps:
       - name: Check for blocking review
         if: github.event_name == 'pull_request_target' || (github.event_name == 'issue_comment' && github.event.issue.pull_request)


### PR DESCRIPTION
We should probably look at not applying this to the repositories that we branch in the future but we can discuss removing it from those in the retrospective post-release.

I'm assuming it's still active for temurin-build, ci-jenkins-pipelines and jenkins-helper.
