### PR TITLE
Add reuseable code freeze target pull request branch regex check workflow

### DIFF
--- a/.github/workflows/code-freeze-regex-branch.yml
+++ b/.github/workflows/code-freeze-regex-branch.yml
@@ -1,0 +1,69 @@
+# ********************************************************************************
+# Copyright (c) 2024 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made
+# available under the terms of the Apache Software License 2.0
+# which is available at https://www.apache.org/licenses/LICENSE-2.0.
+#
+# SPDX-License-Identifier: Apache-2.0
+# ********************************************************************************
+
+name: Code Freeze regex branch check
+
+# Controls when the workflow will run
+on:
+  workflow_call:
+    inputs:
+      branch-regex:
+        required: true
+        type: string
+    outputs:
+      regex-matches:
+        description: "Whether the pull request target branch matches the input branch-regex"
+        value: ${{ jobs.codefreeze_branch_check.outputs.regex-matches }}
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  codefreeze_branch_check:
+    runs-on: ubuntu-latest
+    outputs:
+      regex-matches: ${{ steps.check-freeze-branch.outputs.code_freeze_branch }}
+    steps:
+      - name: Get pull request target branch
+        if: github.event_name == 'pull_request_target' || (github.event_name == 'issue_comment' && github.event.issue.pull_request)
+        id: get-pr-target-branch
+        run: |
+          echo "Getting target branch"
+          if [[ -z $PR_NUMBER ]]; then
+            PR_NUMBER="${{ github.event.pull_request.number }}"
+          fi
+          TARGET_BRANCH="$(gh pr view "$PR_NUMBER" --repo "$REPOSITORY" --json baseRefName --jq '.baseRefName')"
+          echo "pr_target_branch=$TARGET_BRANCH" >> "$GITHUB_OUTPUT"
+          echo "PR target branch = $TARGET_BRANCH"
+        env:
+          REPOSITORY: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.issue.number }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Check if target branch is a code freeze branch
+        if: github.event_name == 'pull_request_target' || (github.event_name == 'issue_comment' && github.event.issue.pull_request)
+        id: check-freeze-branch
+        run: |
+          echo "Checking if $PR_TARGET_BRANCH matches a code freeze branch with regex $BRANCH_REGEX"
+          if echo "$PR_TARGET_BRANCH" | grep -E "$BRANCH_REGEX"; then
+            FREEZE_BRANCH='true'
+          else
+            FREEZE_BRANCH='false'
+          fi
+          echo "code_freeze_branch=$FREEZE_BRANCH" >> "$GITHUB_OUTPUT"
+          echo "Is $PR_TARGET_BRANCH a code freeze branch? => $FREEZE_BRANCH"
+        env:
+          PR_TARGET_BRANCH: ${{ steps.get-pr-target-branch.outputs.pr_target_branch }}
+          BRANCH_REGEX: ${{ inputs.branch-regex }}
+


### PR DESCRIPTION
Part 1 of fix for:
Fixes https://github.com/adoptium/.github/issues/121

This reusable workflow provides a pull request target branch regex comparison logic for "pull_request_target" and "issue_comment" events, which can then be reused in the build repo code-freeze.yml to only match the required target branches to freeze.

It obtains via the github API the pull request target object from which the target branch is matched against the workflow input "branch-regex". it then returns a worflow output of "regex-matches", which will be 'true' for a match against the regex.

Part 2 of this fix will be to update the build repo code-freeze.yml to use this workflow.
