### PR TITLE
Update Semgrep To Run Using latest semgrep container.

### DIFF
--- a/.github/workflows/semgrep_diff.yml
+++ b/.github/workflows/semgrep_diff.yml
@@ -7,7 +7,7 @@ jobs:
   semgrep-diff:
     runs-on: ubuntu-latest
     container:
-      image: returntocorp/semgrep
+      image: semgrep/semgrep
 
     steps:
       # Step 1: Clone application source code


### PR DESCRIPTION
Semgrep container now located at semgrep/semgrep rather than returntocorp